### PR TITLE
Add persisted media lookup

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,14 +1,13 @@
 import Config
 
 config :hlte,
-  api_version: "20220126",
-  header: "x-hlte",
   port: 56555,
   db_path: "./data.sqlite3",
   key_path: "./.keyfile",
   redis_url: nil,
   sns_whitelist: [],
-  delete_sns_s3_post_proc: true
+  delete_sns_s3_post_proc: true,
+  media_data_path: "../persistence/data/"
 
 import_config("#{config_env()}.config.exs")
 

--- a/lib/hlte/application.ex
+++ b/lib/hlte/application.ex
@@ -49,7 +49,7 @@ defmodule HLTE.Application do
     children = [
       {Task.Supervisor, name: HLTE.AsyncSupervisor},
       {HLTE.EmailProcessor, name: EmailProcessor},
-      {HLTE.HTTP, [args[:port], args[:header]]},
+      {HLTE.HTTP, [args[:port], args[:header], args[:media_data_path]]},
       {HLTE.DB, [args[:db_path]]}
     ]
 

--- a/lib/hlte/db.ex
+++ b/lib/hlte/db.ex
@@ -129,7 +129,8 @@ defmodule HLTE.DB do
     {:ok, rows, rowSpec} =
       Basic.exec(
         conn,
-        "select * from hlte
+        "select checksum, timestamp, primaryURI,
+        secondaryURI, hilite, annotation from hlte
       where hilite like '%' || ? || '%'
       or annotation like '%' || ? || '%'
       or primaryURI like '%' || ? || '%'
@@ -150,7 +151,12 @@ defmodule HLTE.DB do
     # transform into a list of maps with key names based on the row names in `rowSpec`
     Enum.map(rows, fn ele ->
       Enum.reduce(0..(length(rowSpec) - 1), %{}, fn idx, acc ->
-        Map.put(acc, Enum.at(rowSpec, idx), Enum.at(ele, idx))
+        key = Enum.at(rowSpec, idx)
+
+        case key do
+          "timestamp" -> Map.put(acc, key, to_string(Enum.at(ele, idx)))
+          _ -> Map.put(acc, key, Enum.at(ele, idx))
+        end
       end)
     end)
   end

--- a/lib/hlte/http/http.ex
+++ b/lib/hlte/http/http.ex
@@ -5,12 +5,12 @@ defmodule HLTE.HTTP do
 
   def start_link(args), do: Task.start_link(__MODULE__, :run, [args])
 
-  def run([listen_port, headerName]) when is_number(listen_port) do
+  def run([listen_port, headerName, mediaDataPath]) when is_number(listen_port) do
     {:ok, _} =
       :cowboy.start_clear(
         :http,
         [{:port, listen_port}],
-        %{:env => %{:dispatch => build_dispatch(headerName)}}
+        %{:env => %{:dispatch => build_dispatch(headerName, mediaDataPath)}}
       )
 
     Logger.notice("HTTP listening on port #{listen_port}")
@@ -18,7 +18,7 @@ defmodule HLTE.HTTP do
     :ok
   end
 
-  def build_dispatch(headerName) do
+  def build_dispatch(headerName, mediaDataPath) do
     :cowboy_router.compile([
       # bind to all interfaces, a la "0.0.0.0"
       {:_,
@@ -29,7 +29,8 @@ defmodule HLTE.HTTP do
 
          # GET
          {"/version", HLTE.HTTP.Route.Version, []},
-         {"/search", HLTE.HTTP.Route.Search, [headerName]}
+         {"/search", HLTE.HTTP.Route.Search, [headerName]},
+         {"/:hash/:ts/[:type]", HLTE.HTTP.Route.GetHiliteMedia, [headerName, mediaDataPath]}
        ]}
     ])
   end

--- a/lib/hlte/http/http.ex
+++ b/lib/hlte/http/http.ex
@@ -30,7 +30,8 @@ defmodule HLTE.HTTP do
          # GET
          {"/version", HLTE.HTTP.Route.Version, []},
          {"/search", HLTE.HTTP.Route.Search, [headerName]},
-         {"/:hash/:ts/[:type]", HLTE.HTTP.Route.GetHiliteMedia, [headerName, mediaDataPath]}
+         {"/:req_ts/:hash/:ts/[:type]", HLTE.HTTP.Route.GetHiliteMedia,
+          [headerName, mediaDataPath]}
        ]}
     ])
   end

--- a/lib/hlte/http/http.ex
+++ b/lib/hlte/http/http.ex
@@ -5,12 +5,12 @@ defmodule HLTE.HTTP do
 
   def start_link(args), do: Task.start_link(__MODULE__, :run, [args])
 
-  def run([listen_port, headerName, mediaDataPath]) when is_number(listen_port) do
+  def run([listen_port, header_name, media_data_path]) when is_number(listen_port) do
     {:ok, _} =
       :cowboy.start_clear(
         :http,
         [{:port, listen_port}],
-        %{:env => %{:dispatch => build_dispatch(headerName, mediaDataPath)}}
+        %{:env => %{:dispatch => build_dispatch(header_name, media_data_path)}}
       )
 
     Logger.notice("HTTP listening on port #{listen_port}")
@@ -18,20 +18,20 @@ defmodule HLTE.HTTP do
     :ok
   end
 
-  def build_dispatch(headerName, mediaDataPath) do
+  def build_dispatch(header_name, media_data_path) do
     :cowboy_router.compile([
       # bind to all interfaces, a la "0.0.0.0"
       {:_,
        [
          # POST
-         {"/", HLTE.HTTP.Route.PostHilite, [headerName]},
+         {"/", HLTE.HTTP.Route.PostHilite, [header_name]},
          {"/sns", HLTE.HTTP.Route.SNSIngest, []},
 
          # GET
          {"/version", HLTE.HTTP.Route.Version, []},
-         {"/search", HLTE.HTTP.Route.Search, [headerName]},
+         {"/search", HLTE.HTTP.Route.Search, [header_name]},
          {"/:req_ts/:hash/:ts/[:type]", HLTE.HTTP.Route.GetHiliteMedia,
-          [headerName, mediaDataPath]}
+          [header_name, media_data_path]}
        ]}
     ])
   end
@@ -42,13 +42,13 @@ defmodule HLTE.HTTP do
 
   Returns a request with the appropriate headers set.
   """
-  def cors_preflight_options(method, req, headerName) do
+  def cors_preflight_options(method, req, header_name) do
     r1 = :cowboy_req.set_resp_header("Access-Control-Allow-Methods", "#{method}, OPTIONS", req)
     r2 = :cowboy_req.set_resp_header("Access-Control-Allow-Origin", "*", r1)
 
     :cowboy_req.set_resp_header(
       "Access-Control-Allow-Headers",
-      "Content-Type, content-type, #{headerName}",
+      "Content-Type, content-type, #{header_name}",
       r2
     )
   end

--- a/lib/hlte/http/routes/get_hilite_media.ex
+++ b/lib/hlte/http/routes/get_hilite_media.ex
@@ -1,46 +1,69 @@
 defmodule HLTE.HTTP.Route.GetHiliteMedia do
   require Logger
 
-  def init(req, [headerName, mediaDataPath])
+  def init(req, [headerName, data_path])
       when is_map_key(req.headers, headerName) and (req.method === "HEAD" or req.method === "GET") do
     HLTE.HTTP.calculate_body_hmac(req.path)
-    |> auth_check(Map.get(req.headers, headerName), req, [headerName, mediaDataPath])
+    |> auth_check(Map.get(req.headers, headerName), req, [headerName, data_path])
   end
 
   def init(req, state) do
     {:ok, :cowboy_req.reply(405, req), state}
   end
 
-  def auth_check(calced_hmac, sent_hmac, req, [headerName, mediaDataPath])
-      when sent_hmac === calced_hmac do
+  def auth_check(calced_hmac, sent_hmac, req, [headerName, data_path])
+      when sent_hmac !== calced_hmac do
     parse_bindings(req.bindings)
-    |> handle_allowed(req, [headerName, mediaDataPath])
+    |> handle_allowed(req, [headerName, data_path])
   end
 
-  def auth_check(calced_hmac, sent_hmac, req, [headerName, mediaDataPath]) do
+  def auth_check(calced_hmac, sent_hmac, req, [headerName, data_path]) do
     Logger.critical("Unauthorized! #{req.method} #{req.path}")
     Logger.warn("#{calced_hmac} !== #{sent_hmac}")
     Logger.warn("Full request: #{inspect(req)}")
-    {:ok, :cowboy_req.reply(403, req), [headerName, mediaDataPath]}
+    {:ok, :cowboy_req.reply(403, req), [headerName, data_path]}
   end
 
-  def handle_allowed([type, basename, hash, ts], req, [headerName, mediaDataPath]) do
-    path_expand = Path.join([mediaDataPath, type]) |> Path.expand()
+  def handle_allowed([type, basename, hash, ts], req, [headerName, data_path]) do
+    case metadata(data_path |> Path.expand(), type, hash, ts) do
+      %{"headers" => headers} when is_map_key(headers, "content-type") ->
+        IO.puts("cool!")
+        [_type, subtype] = Map.get(headers, "content-type") |> String.split("/")
+        full_path = Path.expand(Path.join([data_path, type, "#{basename}.#{subtype}"]))
+        IO.puts("PATH #{full_path}")
+        # FIX!
+        stat = File.stat!(full_path)
+
+        Map.take(headers, ["content-type", "content-length", "last-modified", "age"])
+        |> Enum.to_list()
+        |> Enum.reduce(req, fn {k, v}, acc_req ->
+          :cowboy_req.set_resp_header(k, v, acc_req)
+        end)
+        |> success_reply(stat, full_path, [headerName, data_path])
+
+      _ ->
+        Logger.error("bad metadata!")
+        not_found_reply(req, [headerName, data_path])
+    end
+  end
+
+  def handle_allowed([type, basename, hash, ts], req, [headerName, data_path]) do
+    path_expand = Path.join([data_path, type]) |> Path.expand()
 
     case find_media(path_expand, basename) do
       {:ok, [full_path, stat]} ->
-        case metadata(mediaDataPath |> Path.expand(), type, hash, ts) do
+        case metadata(data_path |> Path.expand(), type, hash, ts) do
           %{"headers" => headers} ->
-              Map.take(headers, ["content-type", "content-length", "last-modified", "age"])
-              |> Enum.to_list()
-              |> Enum.reduce(req, fn {k, v}, acc_req ->
-                :cowboy_req.set_resp_header(k, v, acc_req)
-              end)
-              |> success_reply(stat, full_path, [headerName, mediaDataPath])
+            Map.take(headers, ["content-type", "content-length", "last-modified", "age"])
+            |> Enum.to_list()
+            |> Enum.reduce(req, fn {k, v}, acc_req ->
+              :cowboy_req.set_resp_header(k, v, acc_req)
+            end)
+            |> success_reply(stat, full_path, [headerName, data_path])
 
           _ ->
             Logger.warn("No metadata found! full_path:#{full_path} hash:#{hash} ts:#{ts}")
-            {:ok, req, [headerName, mediaDataPath]}
+            {:ok, req, [headerName, data_path]}
         end
 
       {:error, reason} ->
@@ -48,7 +71,7 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
           Logger.error("find_media failed: #{reason}")
         end
 
-        {:ok, :cowboy_req.reply(404, req), [headerName, mediaDataPath]}
+        {:ok, :cowboy_req.reply(404, req), [headerName, data_path]}
     end
   end
 
@@ -57,7 +80,7 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
     {:ok, :cowboy_req.reply(400, req), state}
   end
 
-  def success_reply(req_with_meta_headers, stat, full_path, [headerName, mediaDataPath])
+  def success_reply(req_with_meta_headers, stat, full_path, [headerName, data_path])
       when req_with_meta_headers.method === "GET" do
     {:ok,
      :cowboy_req.reply(
@@ -66,12 +89,16 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
          {:sendfile, 0, stat.size, full_path},
          req_with_meta_headers
        )
-     ), [headerName, mediaDataPath]}
+     ), [headerName, data_path]}
   end
 
-  def success_reply(req_with_meta_headers, _s, _fp, [headerName, mediaDataPath])
+  def success_reply(req_with_meta_headers, _s, _fp, [headerName, data_path])
       when req_with_meta_headers.method === "HEAD" do
-    {:ok, :cowboy_req.reply(204, req_with_meta_headers), [headerName, mediaDataPath]}
+    {:ok, :cowboy_req.reply(204, req_with_meta_headers), [headerName, data_path]}
+  end
+
+  def not_found_reply(req, [headerName, data_path]) do
+    {:ok, :cowboy_req.reply(404, req), [headerName, data_path]}
   end
 
   def parse_bindings(%{:hash => hash, :ts => ts, :type => "primary"}) do

--- a/lib/hlte/http/routes/get_hilite_media.ex
+++ b/lib/hlte/http/routes/get_hilite_media.ex
@@ -90,7 +90,12 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
 
   def metadata_validate(%{"headers" => headers}, {data_path, type, basename, req, header_name})
       when is_map_key(headers, "content-type") do
-    [_type, subtype] = Map.get(headers, "content-type") |> String.split("/")
+    [_type, subtype] =
+      Map.get(headers, "content-type")
+      |> String.split(";")
+      |> Enum.at(0)
+      |> String.split("/")
+
     full_path = Path.join([data_path, type, "#{basename}.#{subtype}"]) |> Path.expand()
 
     case File.stat(full_path) do

--- a/lib/hlte/http/routes/get_hilite_media.ex
+++ b/lib/hlte/http/routes/get_hilite_media.ex
@@ -79,11 +79,11 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
       Jason.decode!(File.read!(full_path))
     rescue
       fe in File.Error ->
-        Logger.error("Metadata missing, expected at '#{fe.path}'")
+        Logger.error("Metadata missing, expected at #{fe.path}")
         :not_found
 
       je in Jason.DecodeError ->
-        HLTE.LoggingUtil.log_json_error(je, "metadata file at '#{full_path}")
+        HLTE.LoggingUtil.log_json_error(je, "metadata file at #{full_path}")
         :not_found
     end
   end
@@ -103,7 +103,7 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
         |> success_reply(stat, full_path, [header_name, data_path])
 
       {:error, reason} ->
-        Logger.error("File.stat failed on '#{full_path}'")
+        Logger.error("File.stat failed on #{full_path}")
         Logger.error("   #{reason}")
         not_found_reply(req, [header_name, data_path])
     end

--- a/lib/hlte/http/routes/get_hilite_media.ex
+++ b/lib/hlte/http/routes/get_hilite_media.ex
@@ -1,0 +1,103 @@
+defmodule HLTE.HTTP.Route.GetHiliteMedia do
+  require Logger
+
+  def init(req, state) when req.method === "HEAD" do
+    IO.puts("HEAD #{inspect(req)} #{inspect(state)}")
+
+    case parse_bindings(req.bindings) do
+      [type, fileName, hash, ts] ->
+        IO.puts(inspect(type))
+        IO.puts(inspect(fileName))
+
+        path_expand = Path.join([Enum.at(state, 1), type]) |> Path.expand()
+
+        case find_media(path_expand, fileName) do
+          {:ok, [[[base, ext], full_path], stat]} ->
+            IO.puts(inspect(stat))
+            IO.puts(path_expand)
+            IO.puts(full_path)
+
+            case metadata(Enum.at(state, 1) |> Path.expand(), type, hash, ts) do
+              %{"headers" => headers} ->
+                Map.take(headers, ["content-type", "content-length", "last-modified", "age"])
+                |> Enum.to_list()
+                |> Enum.each(fn [k, v] -> IO.puts("-- #{k} -> #{v}") end)
+            end
+
+            {:ok, req, state}
+
+          {:error, reason} ->
+            if reason !== :not_found do
+              Logger.error("find_media failed: #{reason}")
+            end
+
+            {:ok, :cowboy_req.reply(404, req), state}
+        end
+
+      :error ->
+        Logger.error("bad bindings: #{inspect(req.bindings)}")
+        {:ok, :cowboy_req.reply(400, req), state}
+    end
+  end
+
+  def init(req, state) when req.method === "GET" do
+    IO.puts("GET #{inspect(req)} #{inspect(state)}")
+    {:ok, req, state}
+  end
+
+  def init(req, state) do
+    {:ok, :cowboy_req.reply(405, req), state}
+  end
+
+  def parse_bindings(%{:hash => hash, :ts => ts, :type => "primary"}) do
+    ["primary", "#{hash}-#{ts}", hash, ts]
+  end
+
+  def parse_bindings(%{:hash => hash, :ts => ts, :type => "secondary"}) do
+    ["secondary", "#{hash}-#{ts}", hash, ts]
+  end
+
+  def parse_bindings(%{:hash => hash, :ts => ts}) do
+    parse_bindings(%{:hash => hash, :ts => ts, :type => "primary"})
+  end
+
+  def parse_bindings(_) do
+    :error
+  end
+
+  def metadata(path, type, hash, ts) do
+    Jason.decode!(
+      File.read!(Path.expand(Path.join([path, "metadata", "#{hash}-#{ts}.#{type}.json"])))
+    )
+  end
+
+  def find_media(path, fileName) do
+    case File.stat(path) do
+      {:ok, stat} ->
+        # should only refresh the list when stat.mtime has changed?!
+        # could store the cache in ETS
+        IO.puts(
+          "#{path} STAT! #{inspect(stat)} #{inspect(File.ls!(path) |> Enum.map(fn x -> String.split(x, ".") |> Enum.at(0) end))}"
+        )
+
+        case File.ls!(path)
+             |> Enum.map(fn x -> String.split(x, ".") end)
+             |> Enum.filter(fn x -> Enum.at(x, 0) === fileName end)
+             |> Enum.map(fn x -> [x, Path.expand(Path.join([path, Enum.join(x, ".")]))] end)
+             |> Enum.map(fn x -> [x, File.stat!(Enum.at(x, 1))] end) do
+          found_list when length(found_list) === 1 ->
+            {:ok, Enum.at(found_list, 0)}
+
+          found_list when length(found_list) > 1 ->
+            {:error, :multiple_found}
+
+          _ ->
+            {:error, :not_found}
+        end
+
+      {:error, reason} ->
+        Logger.warn("Stat failure for #{path}: #{reason}")
+        {:error, reason}
+    end
+  end
+end

--- a/lib/hlte/http/routes/get_hilite_media.ex
+++ b/lib/hlte/http/routes/get_hilite_media.ex
@@ -1,36 +1,34 @@
 defmodule HLTE.HTTP.Route.GetHiliteMedia do
   require Logger
 
-  def init(req, [headerName, data_path])
-      when is_map_key(req.headers, headerName) and (req.method === "HEAD" or req.method === "GET") do
+  def init(req, [header_name, data_path])
+      when is_map_key(req.headers, header_name) and
+             (req.method === "HEAD" or req.method === "GET") do
     HLTE.HTTP.calculate_body_hmac(req.path)
-    |> auth_check(Map.get(req.headers, headerName), req, [headerName, data_path])
+    |> auth_check(Map.get(req.headers, header_name), req, [header_name, data_path])
   end
 
   def init(req, state) do
     {:ok, :cowboy_req.reply(405, req), state}
   end
 
-  def auth_check(calced_hmac, sent_hmac, req, [headerName, data_path])
+  def auth_check(calced_hmac, sent_hmac, req, [header_name, data_path])
       when sent_hmac === calced_hmac do
     # XXX: must check that the request timestamp isn't too much in the past, to close the reuse vector!!
     parse_bindings(req.bindings)
-    |> handle_allowed(req, [headerName, data_path])
+    |> handle_allowed(req, [header_name, data_path])
   end
 
-  def auth_check(calced_hmac, sent_hmac, req, [headerName, data_path]) do
-    Logger.critical("Unauthorized! #{req.method} #{req.path}")
-    Logger.warn("#{calced_hmac} !== #{sent_hmac}")
-    Logger.warn("Full request: #{inspect(req)}")
-    {:ok, :cowboy_req.reply(403, req), [headerName, data_path]}
+  def auth_check(calced_hmac, _sent_hmac, req, [header_name, data_path]) do
+    HLTE.LoggingUtil.log_unauthorized_req(req, calced_hmac, header_name)
+    {:ok, :cowboy_req.reply(403, req), [header_name, data_path]}
   end
 
-  def handle_allowed([type, basename, hash, ts], req, [headerName, data_path]) do
-    case metadata(data_path |> Path.expand(), type, hash, ts) do
+  def handle_allowed([type, basename, hash, ts], req, [header_name, data_path]) do
+    case metadata_parse(data_path |> Path.expand(), type, hash, ts) do
       %{"headers" => headers} when is_map_key(headers, "content-type") ->
-        IO.puts("cool!")
         [_type, subtype] = Map.get(headers, "content-type") |> String.split("/")
-        full_path = Path.expand(Path.join([data_path, type, "#{basename}.#{subtype}"]))
+        full_path = Path.join([data_path, type, "#{basename}.#{subtype}"]) |> Path.expand()
         IO.puts("PATH #{full_path}")
         # FIX!
         stat = File.stat!(full_path)
@@ -40,11 +38,15 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
         |> Enum.reduce(req, fn {k, v}, acc_req ->
           :cowboy_req.set_resp_header(k, v, acc_req)
         end)
-        |> success_reply(stat, full_path, [headerName, data_path])
+        |> success_reply(stat, full_path, [header_name, data_path])
 
-      _ ->
-        Logger.error("bad metadata!")
-        not_found_reply(req, [headerName, data_path])
+      error ->
+        if error !== :not_found do
+          Logger.critical("Unknown error! #{inspect(error)}")
+        end
+
+        Logger.warn("Full request: #{inspect(req)}")
+        not_found_reply(req, [header_name, data_path])
     end
   end
 
@@ -53,7 +55,7 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
     {:ok, :cowboy_req.reply(400, req), state}
   end
 
-  def success_reply(req_with_meta_headers, stat, full_path, [headerName, data_path])
+  def success_reply(req_with_meta_headers, stat, full_path, [header_name, data_path])
       when req_with_meta_headers.method === "GET" do
     {:ok,
      :cowboy_req.reply(
@@ -62,16 +64,16 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
          {:sendfile, 0, stat.size, full_path},
          req_with_meta_headers
        )
-     ), [headerName, data_path]}
+     ), [header_name, data_path]}
   end
 
-  def success_reply(req_with_meta_headers, _s, _fp, [headerName, data_path])
+  def success_reply(req_with_meta_headers, _s, _fp, [header_name, data_path])
       when req_with_meta_headers.method === "HEAD" do
-    {:ok, :cowboy_req.reply(204, req_with_meta_headers), [headerName, data_path]}
+    {:ok, :cowboy_req.reply(204, req_with_meta_headers), [header_name, data_path]}
   end
 
-  def not_found_reply(req, [headerName, data_path]) do
-    {:ok, :cowboy_req.reply(404, req), [headerName, data_path]}
+  def not_found_reply(req, [header_name, data_path]) do
+    {:ok, :cowboy_req.reply(404, req), [header_name, data_path]}
   end
 
   def parse_bindings(%{:hash => hash, :ts => ts, :type => "primary"}) do
@@ -90,9 +92,19 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
     :error
   end
 
-  def metadata(path, type, hash, ts) do
-    Jason.decode!(
-      File.read!(Path.expand(Path.join([path, "metadata", "#{hash}-#{ts}.#{type}.json"])))
-    )
+  def metadata_parse(path, type, hash, ts) do
+    full_path = Path.join([path, "metadata", "#{hash}-#{ts}.#{type}.json"]) |> Path.expand()
+
+    try do
+      Jason.decode!(File.read!(full_path))
+    rescue
+      fe in File.Error ->
+        Logger.error("Metadata missing, expected at '#{fe.path}'")
+        :not_found
+
+      je in Jason.DecodeError ->
+        HLTE.LoggingUtil.log_json_error(je, "metadata file at '#{full_path}")
+        :not_found
+    end
   end
 end

--- a/lib/hlte/http/routes/get_hilite_media.ex
+++ b/lib/hlte/http/routes/get_hilite_media.ex
@@ -92,7 +92,6 @@ defmodule HLTE.HTTP.Route.GetHiliteMedia do
       when is_map_key(headers, "content-type") do
     [_type, subtype] = Map.get(headers, "content-type") |> String.split("/")
     full_path = Path.join([data_path, type, "#{basename}.#{subtype}"]) |> Path.expand()
-    IO.puts("PATH #{full_path}")
 
     case File.stat(full_path) do
       {:ok, stat} ->

--- a/lib/hlte/http/routes/search.ex
+++ b/lib/hlte/http/routes/search.ex
@@ -21,6 +21,7 @@ defmodule HLTE.HTTP.Route.Search do
   end
 
   def get_json(req, [headerName]) when is_map_key(req.headers, headerName) do
+    # XXX: must check that the request timestamp isn't too much in the past, to close the reuse vector!!
     %{d: newestFirst, l: limit, q: query} = :cowboy_req.match_qs([:d, :l, :q], req)
 
     case search(

--- a/lib/hlte/http/routes/sns_ingest.ex
+++ b/lib/hlte/http/routes/sns_ingest.ex
@@ -49,14 +49,8 @@ defmodule HLTE.HTTP.Route.SNSIngest do
     :error
   end
 
-  defp ingest_post({:error, %Jason.DecodeError{:data => d, :position => p, :token => t}}) do
-    Logger.error("Malformed POST JSON!")
-    Logger.error("   at position #{p}, token '#{t}' in data: #{d}")
-    :error
-  end
-
-  defp ingest_post({:error, unkErr}) do
-    Logger.error("Malformed POST! Unknown error: #{inspect(unkErr)}")
+  defp ingest_post({:error, decode_error}) do
+    HLTE.LoggingUtil.log_json_error(decode_error)
     :error
   end
 end

--- a/lib/hlte/logging_util.ex
+++ b/lib/hlte/logging_util.ex
@@ -1,0 +1,17 @@
+defmodule HLTE.LoggingUtil do
+  require Logger
+
+  def log_json_error(
+        %Jason.DecodeError{:data => d, :position => p, :token => t},
+        descriptor \\ "POST"
+      ) do
+    Logger.error("Malformed JSON in #{descriptor}")
+    Logger.error("   at position #{p}, token '#{t}' in data: #{d}")
+  end
+
+  def log_unauthorized_req(req, calced_hmac, header_name) do
+    Logger.critical("Unauthorized! #{req.method} #{req.path}")
+    Logger.warn("#{Map.get(req.headers, header_name)} !== #{calced_hmac}")
+    Logger.warn("Full request: #{inspect(req)}")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,10 +15,11 @@ defmodule HLTE.MixProject do
 
   def application do
     envArgs = [
-      header: fe(:header),
+      header: "x-hlte",
       port: fe(:port),
       db_path: fe(:db_path),
-      key_path: fe(:key_path)
+      key_path: fe(:key_path),
+      media_data_path: fe(:media_data_path)
     ]
 
     Logger.notice("App v#{project()[:version]} started with config #{inspect(envArgs)}")
@@ -27,6 +28,7 @@ defmodule HLTE.MixProject do
       extra_applications: [:logger],
       mod: {HLTE.Application, envArgs},
       env: [
+        api_version: "20220126",
         args: envArgs
       ]
     ]


### PR DESCRIPTION
Adds [`http/routes/get_hilite_media.ex`](https://github.com/hlte-net/elixir-daemon/compare/get_hilite_media?expand=1#diff-9e21ebcc785c6f480f5be227f74e39a2ecf9da2b8b059efdbc2ec1de5f10da26) which allows `HEAD` and `GET` of [persisted](https://github.com/hlte-net/persistence) media.